### PR TITLE
We can't rely on OS being what we expect, so set BUILD_HARNESS_OS ourselves

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 export BUILD_HARNESS_PATH ?= $(shell 'pwd')
 export BUILD_HARNESS_EXTENSIONS_PATH ?= $(BUILD_HARNESS_PATH)/../build-harness-extensions
-export BUILD_HARNESS_OS ?= $(OS)
+export BUILD_HARNESS_OS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 export BUILD_HARNESS_ARCH ?= $(shell uname -m | sed 's/x86_64/amd64/g')
 export SELF ?= $(MAKE)
 export PATH := $(BUILD_HARNESS_PATH)/vendor:$(PATH)


### PR DESCRIPTION
With OS being such a short name, collisions are easy to happen.  Protect BUILD_HARNESS_OS by setting it explicitly.

